### PR TITLE
Fix typo in Dockerfile path in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ env:
   # Configurações do Projeto
   SOLUTION_FILE: 'Postech.Fiap.CartsPayments.sln'
   TEST_PROJECT: 'test/Postech.Fiap.CartsPayments.WebApi.UnitTests'
-  DOCKERFILE_PATH: 'src/Postech.Fiap.CartsPayments'.WebApi/Dockerfile'
+  DOCKERFILE_PATH: 'src/Postech.Fiap.CartsPayments.WebApi/Dockerfile'
   DOCKER_IMAGE_NAME: 'myfood-carts-payments-webapi'
   COVERAGE_FILE: 'coverage.xml'
 


### PR DESCRIPTION
Corrected the Dockerfile path in the GitHub Actions deploy workflow file. This ensures the pipeline can locate the Dockerfile correctly and proceed without errors.